### PR TITLE
Export fields in ROMFile

### DIFF
--- a/nes/cnrom.go
+++ b/nes/cnrom.go
@@ -11,7 +11,7 @@ type CNROMRegisters struct {
 }
 
 type CNROM struct {
-	*ROMFile  `json:"-"`
+	*ROMFile
 	Registers CNROMRegisters
 }
 
@@ -40,7 +40,7 @@ func (cnrom *CNROM) Mappings(which rp2ago3.Mapping) (fetch, store []uint16) {
 
 	switch which {
 	case rp2ago3.PPU:
-		if cnrom.ROMFile.chrBanks > 0 {
+		if cnrom.CHRBanks > 0 {
 			// CHR bank 1
 			for i := uint32(0x0000); i <= 0x0fff; i++ {
 				fetch = append(fetch, uint16(i))
@@ -54,7 +54,7 @@ func (cnrom *CNROM) Mappings(which rp2ago3.Mapping) (fetch, store []uint16) {
 			}
 		}
 	case rp2ago3.CPU:
-		if cnrom.ROMFile.prgBanks > 0 {
+		if cnrom.PRGBanks > 0 {
 			// PRG bank 1
 			for i := uint32(0x8000); i <= 0xbfff; i++ {
 				fetch = append(fetch, uint16(i))
@@ -80,8 +80,8 @@ func (cnrom *CNROM) Fetch(address uint16) (value uint8) {
 	switch {
 	// PPU only
 	case address >= 0x0000 && address <= 0x1fff:
-		if cnrom.ROMFile.chrBanks > 0 {
-			value = cnrom.ROMFile.vromBanks[cnrom.Registers.BankSelect][address]
+		if cnrom.CHRBanks > 0 {
+			value = cnrom.VROMBanks[cnrom.Registers.BankSelect][address]
 		}
 	// CPU only
 	case address >= 0x8000 && address <= 0xffff:
@@ -90,13 +90,13 @@ func (cnrom *CNROM) Fetch(address uint16) (value uint8) {
 		switch {
 		// PRG bank 1
 		case address >= 0x8000 && address <= 0xbfff:
-			if cnrom.ROMFile.prgBanks > 0 {
-				value = cnrom.ROMFile.romBanks[0][index]
+			if cnrom.PRGBanks > 0 {
+				value = cnrom.ROMBanks[0][index]
 			}
 		// PRG bank 2
 		case address >= 0xc000 && address <= 0xffff:
-			if cnrom.ROMFile.prgBanks > 0 {
-				value = cnrom.ROMFile.romBanks[cnrom.ROMFile.prgBanks-1][index]
+			if cnrom.PRGBanks > 0 {
+				value = cnrom.ROMBanks[cnrom.PRGBanks-1][index]
 			}
 		}
 	}
@@ -109,8 +109,8 @@ func (cnrom *CNROM) Store(address uint16, value uint8) (oldValue uint8) {
 	switch {
 	// CHR banks 1 & 2
 	case address >= 0x0000 && address <= 0x1fff:
-		if cnrom.ROMFile.chrBanks > 0 {
-			cnrom.ROMFile.vromBanks[cnrom.Registers.BankSelect][address] = value
+		if cnrom.CHRBanks > 0 {
+			cnrom.VROMBanks[cnrom.Registers.BankSelect][address] = value
 		}
 	// CPU only
 	// PRG banks 1 & 2

--- a/nes/nes.go
+++ b/nes/nes.go
@@ -222,7 +222,7 @@ func (nes *NES) SaveState() {
 
 	enc := json.NewEncoder(vfw)
 
-	if err = enc.Encode(struct{ Version string }{"0.2"}); err != nil {
+	if err = enc.Encode(struct{ Version string }{"0.3"}); err != nil {
 		fmt.Printf("*** Error saving state: %s\n", err)
 		return
 	}
@@ -277,7 +277,7 @@ func (nes *NES) LoadState() {
 				return
 			}
 
-			if v.Version != "0.2" {
+			if v.Version != "0.3" {
 				fmt.Printf("*** Error loading state: Invalid save state format version '%s'\n", v.Version)
 				return
 			}

--- a/nes/nrom.go
+++ b/nes/nrom.go
@@ -7,7 +7,7 @@ import (
 )
 
 type NROM struct {
-	*ROMFile `json:"-"`
+	*ROMFile
 }
 
 func NewNROM(romf *ROMFile) *NROM {
@@ -25,7 +25,7 @@ func (nrom *NROM) Mappings(which rp2ago3.Mapping) (fetch, store []uint16) {
 
 	switch which {
 	case rp2ago3.PPU:
-		if nrom.ROMFile.chrBanks > 0 {
+		if nrom.CHRBanks > 0 {
 			// CHR bank 1
 			for i := uint32(0x0000); i <= 0x0fff; i++ {
 				fetch = append(fetch, uint16(i))
@@ -39,7 +39,7 @@ func (nrom *NROM) Mappings(which rp2ago3.Mapping) (fetch, store []uint16) {
 			}
 		}
 	case rp2ago3.CPU:
-		if nrom.ROMFile.prgBanks > 0 {
+		if nrom.PRGBanks > 0 {
 			// PRG bank 1
 			for i := uint32(0x8000); i <= 0xbfff; i++ {
 				fetch = append(fetch, uint16(i))
@@ -63,8 +63,8 @@ func (nrom *NROM) Fetch(address uint16) (value uint8) {
 	switch {
 	// PPU only
 	case address >= 0x0000 && address <= 0x1fff:
-		if nrom.ROMFile.chrBanks > 0 {
-			value = nrom.ROMFile.vromBanks[0][address]
+		if nrom.CHRBanks > 0 {
+			value = nrom.VROMBanks[0][address]
 		}
 	// CPU only
 	case address >= 0x8000 && address <= 0xffff:
@@ -73,13 +73,13 @@ func (nrom *NROM) Fetch(address uint16) (value uint8) {
 		switch {
 		// PRG bank 1
 		case address >= 0x8000 && address <= 0xbfff:
-			if nrom.ROMFile.prgBanks > 0 {
-				value = nrom.ROMFile.romBanks[0][index]
+			if nrom.PRGBanks > 0 {
+				value = nrom.ROMBanks[0][index]
 			}
 		// PRG bank 2
 		case address >= 0xc000 && address <= 0xffff:
-			if nrom.ROMFile.prgBanks > 0 {
-				value = nrom.ROMFile.romBanks[nrom.ROMFile.prgBanks-1][index]
+			if nrom.PRGBanks > 0 {
+				value = nrom.ROMBanks[nrom.PRGBanks-1][index]
 			}
 		}
 	}
@@ -92,8 +92,8 @@ func (nrom *NROM) Store(address uint16, value uint8) (oldValue uint8) {
 	switch {
 	// CHR banks 1 & 2
 	case address >= 0x0000 && address <= 0x1fff:
-		if nrom.ROMFile.chrBanks > 0 {
-			nrom.ROMFile.vromBanks[0][address] = value
+		if nrom.CHRBanks > 0 {
+			nrom.VROMBanks[0][address] = value
 		}
 	}
 

--- a/nes/rom_test.go
+++ b/nes/rom_test.go
@@ -122,7 +122,7 @@ func TestPrgBanks(t *testing.T) {
 		return
 	}
 
-	if rom.prgBanks != 0x01 {
+	if rom.PRGBanks != 0x01 {
 		t.Error("RomBanks is not 0x01")
 	}
 
@@ -138,8 +138,8 @@ func TestPrgBanks(t *testing.T) {
 			val = 0xff
 		}
 
-		if rom.romBanks[0][i] != val {
-			t.Errorf("ROM bank 0 data index %v is %02X not %02X\n", i, rom.romBanks[0][i], val)
+		if rom.ROMBanks[0][i] != val {
+			t.Errorf("ROM bank 0 data index %v is %02X not %02X\n", i, rom.ROMBanks[0][i], val)
 		}
 	}
 }
@@ -198,7 +198,7 @@ func TestChrBanks(t *testing.T) {
 		return
 	}
 
-	if rom.chrBanks != 0x01 {
+	if rom.CHRBanks != 0x01 {
 		t.Error("VRomBanks is not 0x01")
 	}
 
@@ -214,8 +214,8 @@ func TestChrBanks(t *testing.T) {
 			val = 0xff
 		}
 
-		if rom.vromBanks[0][i] != val {
-			t.Errorf("VROM bank 0 data index %v is %02X not %02X\n", i, rom.vromBanks[0][i], val)
+		if rom.VROMBanks[0][i] != val {
+			t.Errorf("VROM bank 0 data index %v is %02X not %02X\n", i, rom.VROMBanks[0][i], val)
 		}
 	}
 }
@@ -235,7 +235,7 @@ func TestMirroring(t *testing.T) {
 		return
 	}
 
-	if rom.mirroring != rp2cgo2.Horizontal {
+	if rom.Mirroring != rp2cgo2.Horizontal {
 		t.Error("Mirroring is not Horizontal")
 	}
 
@@ -253,7 +253,7 @@ func TestMirroring(t *testing.T) {
 		return
 	}
 
-	if rom.mirroring != rp2cgo2.Vertical {
+	if rom.Mirroring != rp2cgo2.Vertical {
 		t.Error("Mirroring is not Vertical")
 	}
 
@@ -274,7 +274,7 @@ func TestBattery(t *testing.T) {
 		return
 	}
 
-	if rom.battery {
+	if rom.Battery {
 		t.Error("Battery is true")
 	}
 
@@ -292,7 +292,7 @@ func TestBattery(t *testing.T) {
 		return
 	}
 
-	if !rom.battery {
+	if !rom.Battery {
 		t.Error("Battery is false")
 	}
 
@@ -313,7 +313,7 @@ func TestTrainer(t *testing.T) {
 		return
 	}
 
-	if rom.trainer {
+	if rom.Trainer {
 		t.Error("Trainer is true")
 	}
 
@@ -353,12 +353,12 @@ func TestTrainer(t *testing.T) {
 		return
 	}
 
-	if !rom.trainer {
+	if !rom.Trainer {
 		t.Error("Trainer is false")
 	}
 
 	for i := 0; i < 512; i++ {
-		if rom.trainerData[i] != 0xff {
+		if rom.TrainerData[i] != 0xff {
 			t.Error("Trainer data is not all 0xff")
 		}
 	}
@@ -379,7 +379,7 @@ func TestFourScreen(t *testing.T) {
 		return
 	}
 
-	if rom.fourScreen {
+	if rom.FourScreen {
 		t.Error("FourScreen is true")
 	}
 
@@ -397,7 +397,7 @@ func TestFourScreen(t *testing.T) {
 		return
 	}
 
-	if !rom.fourScreen {
+	if !rom.FourScreen {
 		t.Error("FourScreen is false")
 	}
 
@@ -418,7 +418,7 @@ func TestMapperLow(t *testing.T) {
 		return
 	}
 
-	if rom.mapper != 0x00 {
+	if rom.Mapper != 0x00 {
 		t.Error("Mapper is not 0x00")
 	}
 
@@ -436,7 +436,7 @@ func TestMapperLow(t *testing.T) {
 		return
 	}
 
-	if rom.mapper != 0x0f {
+	if rom.Mapper != 0x0f {
 		t.Error("Mapper is not 0x0f")
 	}
 }
@@ -456,7 +456,7 @@ func TestVsCart(t *testing.T) {
 		return
 	}
 
-	if rom.vsCart {
+	if rom.VSCart {
 		t.Error("VSCart is true")
 	}
 
@@ -474,7 +474,7 @@ func TestVsCart(t *testing.T) {
 		return
 	}
 
-	if !rom.vsCart {
+	if !rom.VSCart {
 		t.Error("VSCart is false")
 	}
 
@@ -495,7 +495,7 @@ func TestMapperHigh(t *testing.T) {
 		return
 	}
 
-	if rom.mapper != 0x00 {
+	if rom.Mapper != 0x00 {
 		t.Error("Mapper is not 0x00")
 	}
 
@@ -513,7 +513,7 @@ func TestMapperHigh(t *testing.T) {
 		return
 	}
 
-	if rom.mapper != 0xf0 {
+	if rom.Mapper != 0xf0 {
 		t.Error("Mapper is not 0xf0")
 	}
 }
@@ -533,7 +533,7 @@ func TestMapper(t *testing.T) {
 		return
 	}
 
-	if rom.mapper != 0x00 {
+	if rom.Mapper != 0x00 {
 		t.Error("Mapper is not 0x00")
 	}
 
@@ -551,7 +551,7 @@ func TestMapper(t *testing.T) {
 		return
 	}
 
-	if rom.mapper != 0xff {
+	if rom.Mapper != 0xff {
 		t.Error("Mapper is not 0xff")
 	}
 }
@@ -571,7 +571,7 @@ func TestRamBanks(t *testing.T) {
 		return
 	}
 
-	if rom.ramBanks != 0xff {
+	if rom.RAMBanks != 0xff {
 		t.Error("RamBanks is not 0xff")
 	}
 
@@ -589,7 +589,7 @@ func TestRamBanks(t *testing.T) {
 		return
 	}
 
-	if rom.ramBanks != 0x01 {
+	if rom.RAMBanks != 0x01 {
 		t.Error("RamBanks is not 0x01")
 	}
 }
@@ -609,7 +609,7 @@ func TestRegion(t *testing.T) {
 		return
 	}
 
-	if rom.region != NTSC {
+	if rom.RegionFlag != NTSC {
 		t.Error("Region is not NTSC")
 	}
 
@@ -627,7 +627,7 @@ func TestRegion(t *testing.T) {
 		return
 	}
 
-	if rom.region != PAL {
+	if rom.RegionFlag != PAL {
 		t.Error("Region is not PAL")
 	}
 

--- a/nes/unrom.go
+++ b/nes/unrom.go
@@ -11,7 +11,7 @@ type UNROMRegisters struct {
 }
 
 type UNROM struct {
-	*ROMFile  `json:"-"`
+	*ROMFile
 	Registers UNROMRegisters
 }
 
@@ -40,7 +40,7 @@ func (unrom *UNROM) Mappings(which rp2ago3.Mapping) (fetch, store []uint16) {
 
 	switch which {
 	case rp2ago3.PPU:
-		if unrom.ROMFile.chrBanks > 0 {
+		if unrom.CHRBanks > 0 {
 			// CHR bank 1
 			for i := uint32(0x0000); i <= 0x0fff; i++ {
 				fetch = append(fetch, uint16(i))
@@ -54,7 +54,7 @@ func (unrom *UNROM) Mappings(which rp2ago3.Mapping) (fetch, store []uint16) {
 			}
 		}
 	case rp2ago3.CPU:
-		if unrom.ROMFile.prgBanks > 0 {
+		if unrom.PRGBanks > 0 {
 			// PRG bank 1
 			for i := uint32(0x8000); i <= 0xbfff; i++ {
 				fetch = append(fetch, uint16(i))
@@ -80,8 +80,8 @@ func (unrom *UNROM) Fetch(address uint16) (value uint8) {
 	switch {
 	// PPU only
 	case address >= 0x0000 && address <= 0x1fff:
-		if unrom.ROMFile.chrBanks > 0 {
-			value = unrom.ROMFile.vromBanks[0][address]
+		if unrom.CHRBanks > 0 {
+			value = unrom.VROMBanks[0][address]
 		}
 	// CPU only
 	case address >= 0x8000 && address <= 0xffff:
@@ -90,13 +90,13 @@ func (unrom *UNROM) Fetch(address uint16) (value uint8) {
 		switch {
 		// PRG bank 1
 		case address >= 0x8000 && address <= 0xbfff:
-			if unrom.ROMFile.prgBanks > 0 {
-				value = unrom.ROMFile.romBanks[unrom.Registers.BankSelect][index]
+			if unrom.PRGBanks > 0 {
+				value = unrom.ROMBanks[unrom.Registers.BankSelect][index]
 			}
 		// PRG bank 2
 		case address >= 0xc000 && address <= 0xffff:
-			if unrom.ROMFile.prgBanks > 0 {
-				value = unrom.ROMFile.romBanks[unrom.ROMFile.prgBanks-1][index]
+			if unrom.PRGBanks > 0 {
+				value = unrom.ROMBanks[unrom.PRGBanks-1][index]
 			}
 		}
 	}
@@ -109,8 +109,8 @@ func (unrom *UNROM) Store(address uint16, value uint8) (oldValue uint8) {
 	switch {
 	// CHR banks 1 & 2
 	case address >= 0x0000 && address <= 0x1fff:
-		if unrom.ROMFile.chrBanks > 0 {
-			unrom.ROMFile.vromBanks[0][address] = value
+		if unrom.CHRBanks > 0 {
+			unrom.VROMBanks[0][address] = value
 		}
 	// CPU only
 	// PRG banks 1 & 2


### PR DESCRIPTION
Remove `json:"-"` tag from embedded ROMFile in mapper structs so that
it gets stored in JSON save state files

This is so that ROM instances can be transfered via gob package

Simplify access to ROMFile fields in mapper code:

nrom.ROMFile.wramBanks -> nrom.WRAMBanks

Bumped version in meta.json to 0.3
